### PR TITLE
pvoutput-ocf==0.1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pyyaml
 urllib3
 requests
 nowcasting_datamodel
-pvoutput-ocf
+pvoutput-ocf==0.1.10
 click


### PR DESCRIPTION
# Pull Request

## Description

this adds timezones to the datetimes in the pv status data

Fixes #

## How Has This Been Tested?

normal unittests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
